### PR TITLE
Support new ssd model Virtium VTSM24ABXI160-BM110006

### DIFF
--- a/sonic_platform_base/sonic_storage/ssd.py
+++ b/sonic_platform_base/sonic_storage/ssd.py
@@ -253,11 +253,13 @@ class SsdUtil(StorageCommon):
                     pass
             else:
                 health_raw = NOT_AVAILABLE
+                # The ID of "Remaining Life Left" attribute on 'VSFDM8XC240G-V11-T' 
+                # and 'Virtium VTSM24ABXI160-BM110006' device is 231
+                # However, it is not recognized by SmartCmd nor smartctl so far
+                # We need to parse them using the ID number
+                special_ssd = ['VSFDM8XC240G-V11-T', 'Virtium VTSM24ABXI160-BM110006']
                 try:
-                    if self.model == 'VSFDM8XC240G-V11-T':
-                        # The ID of "Remaining Life Left" attribute on 'VSFDM8XC240G-V11-T' device is 231
-                        # However, it is not recognized by SmartCmd nor smartctl so far
-                        # We need to parse it using the ID number
+                    if self.model in special_ssd:
                         health_raw = self.parse_id_number(VIRTIUM_HEALTH_ID, self.vendor_ssd_info)
                         self.health = float(health_raw.split()[2]) if health_raw != NOT_AVAILABLE else NOT_AVAILABLE
                     else:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
The ID of "Remaining Life Left" attribute on  'Virtium VTSM24ABXI160-BM110006' device is 231. 
However, it is not recognized by SmartCmd nor smartctl so far so we need to parse it using the ID number.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

The Virtium prefix of the device model is shown from smartctl output, so keep it.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
show platform ssdhealth
Device Model : Virtium VTSM24ABXI160-BM110006
Health       : 100.0%
Temperature  : 52C

#### Additional Information (Optional)

